### PR TITLE
Adds label as tooltip for reaction item

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
-androidx-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-agp = "8.3.1"
+agp = "8.3.2"
 kotlin = "1.9.22"
 material = "1.11.0"
 activityCompose = "1.8.2"
-composeBom = "2024.03.00"
+composeBom = "2024.04.00"
 
 [libraries]
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.foundation)
+    implementation(libs.androidx.material3)
 
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -67,7 +67,7 @@ afterEvaluate {
 
                 groupId = "com.github.amsavarthan"
                 artifactId = "reaction-picker"
-                version = "1.0.0"
+                version = "1.1.0"
 
                 pom {
                     name = "Reaction Picker"


### PR DESCRIPTION
**What was the issue?**

The issue with the reaction icon item was that when the icon size changed upon hovering, the layout expanded due to the added width of the label, causing animation jank.

**Changes made:**

To address this, the label was redesigned as a popup. Instead of creating a custom popup layout, the tooltip from the material3 package was utilized for this functionality.